### PR TITLE
OTAB-25: Allow creation of instance profile

### DIFF
--- a/aws_iam_role.tf
+++ b/aws_iam_role.tf
@@ -3,4 +3,3 @@ resource "aws_iam_role" "local_codebuild_role" {
   description        = "Managed by Terraform"
   assume_role_policy = data.aws_iam_policy_document.forrole.json
 }
-

--- a/aws_iam_role_packer_instance_profile.tf
+++ b/aws_iam_role_packer_instance_profile.tf
@@ -1,0 +1,131 @@
+resource "aws_iam_role" "codebuild_instance_role" {
+  name = "CODEBUILD-PACKER-IAM-ROLE"
+
+  assume_role_policy = <<POLICY
+{
+  "Version": "2008-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "ec2.amazonaws.com",
+          "ssm.amazonaws.com"
+        ]
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+POLICY
+}
+
+resource "aws_iam_role_policy" "codebuild_instance_policy" {
+  name = "CODEBUILD-PACKER-INSTANCE-POLICY"
+
+  role = aws_iam_role.codebuild_instance_role.id
+
+  policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ssm:DescribeInstanceInformation",
+                "ssm:DescribeAssociation",
+                "ssm:GetDeployablePatchSnapshotForInstance",
+                "ssm:GetDocument",
+                "ssm:GetManifest",
+                "ssm:GetParameters",
+                "ssm:GetParameter",
+                "ssm:ListAssociations",
+                "ssm:ListInstanceAssociations",
+                "ssm:PutInventory",
+                "ssm:PutComplianceItems",
+                "ssm:PutConfigurePackageResult",
+                "ssm:UpdateAssociationStatus",
+                "ssm:UpdateInstanceAssociationStatus",
+                "ssm:UpdateInstanceInformation"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "secretsmanager:GetSecretValue"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Resource": "*",
+            "Effect": "Allow",
+            "Action": [
+                "ssmmessages:CreateControlChannel",
+                "ssmmessages:CreateDataChannel",
+                "ssmmessages:OpenControlChannel",
+                "ssmmessages:OpenDataChannel"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2messages:AcknowledgeMessage",
+                "ec2messages:DeleteMessage",
+                "ec2messages:FailMessage",
+                "ec2messages:GetEndpoint",
+                "ec2messages:GetMessages",
+                "ec2messages:SendReply"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "cloudwatch:PutMetricData"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:DescribeInstanceStatus",
+                "ec2:CreateTags"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "logs:CreateLogGroup",
+                "logs:CreateLogStream",
+                "logs:DescribeLogGroups",
+                "logs:DescribeLogStreams",
+                "logs:PutLogEvents"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "s3:PutObject",
+                "s3:GetObject",
+                "s3:AbortMultipartUpload",
+                "s3:ListMultipartUploadParts",
+                "s3:ListBucket",
+                "s3:ListBucketMultipartUploads"
+            ],
+            "Resource": [
+                "arn:aws:s3:::${var.s3_resource_name}",
+                "arn:aws:s3:::${var.s3_resource_name}/*"
+            ]
+        }
+    ]
+}
+EOF
+}
+
+resource "aws_iam_instance_profile" "codebuild_ec2_iam_profile" {
+  name = "CODEBUILD-PACKER-IAM-PROFILE"
+  role = aws_iam_role.codebuild_instance_role.name
+}

--- a/aws_iam_role_packer_instance_profile.tf
+++ b/aws_iam_role_packer_instance_profile.tf
@@ -1,5 +1,5 @@
 resource "aws_iam_role" "codebuild_instance_role" {
-  name = "CODEBUILD-PACKER-IAM-ROLE"
+  name = "CODEBUILD-PACKER-${upper(var.project_name)}-IAM-ROLE"
 
   assume_role_policy = <<POLICY
 {
@@ -21,7 +21,7 @@ POLICY
 }
 
 resource "aws_iam_role_policy" "codebuild_instance_policy" {
-  name = "CODEBUILD-PACKER-INSTANCE-POLICY"
+  name = "CODEBUILD-PACKER-${upper(var.project_name)}-INSTANCE-POLICY"
 
   role = aws_iam_role.codebuild_instance_role.id
 
@@ -126,6 +126,6 @@ EOF
 }
 
 resource "aws_iam_instance_profile" "codebuild_ec2_iam_profile" {
-  name = "CODEBUILD-PACKER-IAM-PROFILE"
+  name = "CODEBUILD-PACKER-${upper(var.project_name)}-IAM-PROFILE"
   role = aws_iam_role.codebuild_instance_role.name
 }

--- a/data_policy_local_codebuild.tf
+++ b/data_policy_local_codebuild.tf
@@ -31,12 +31,12 @@ data "aws_iam_policy_document" "local_codebuild" {
     effect = "Allow"
   }
   statement {
-    sid       = "allowPackerPassRole"
-    effect    = "Allow"
-    actions   = [
+    sid    = "allowPackerPassRole"
+    effect = "Allow"
+    actions = [
       "iam:PassRole",
       "iam:GetInstanceProfile"
-      ]
+    ]
     resources = ["*"]
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -71,6 +71,11 @@ variable "common_tags" {
   type = map(string)
 }
 
+variable "s3_resource_name" {
+  description = "Name of a pre-existing module to allow access for build resources"
+  type        = string
+}
+
 locals {
   ami_install_commands = [
   ]


### PR DESCRIPTION
The instance-profile is required so it can be assigned to the instances used by packer.

The profile requires access to S3 so it can pull build resources

Previously the instance profile was created elsewhere

* This may affect projects already using this module since it changes the required parameters *